### PR TITLE
Minor fixes

### DIFF
--- a/dist/config.yml
+++ b/dist/config.yml
@@ -1,13 +1,13 @@
 ---
 openWeatherApi:
-  appid: "<YOUR OPEN WEATHER API API KEY GOES HERE."
+  appid: "<YOUR OPEN WEATHER API API KEY GOES HERE.>"
 openStreetMap:
   base_url: "https://nominatim.openstreetmap.org"
 service:
   listen_port: 9999
   user_agent: "QuickWeather/1.0"
 cache:
-  temperature_max_age: 1800
+  temperature_max_age: 300
 db:
   user: "vagrant"
   password: "vagrant"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": "10.16.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "setup": "cp config/config.json.dist config/config.json && cp dist/config.yml config.yml && npm run migrate:up && echo \"Please edit config.yml. See README.md for more details.\"",
+    "setup": "npm ci && cp config/config.json.dist config/config.json && cp dist/config.yml config.yml && npm run migrate:up && echo \"Please edit config.yml. See README.md for more details.\"",
     "start": "node src/server.js",
     "migrate:up": "./node_modules/.bin/sequelize db:migrate",
     "migrate:down": "./node_modules/.bin/sequelize db:migrate:undo"


### PR DESCRIPTION
* Configure the timeout of the cache to be 5 minutes instead of 30 in the distributed example configuration file.
* Make sure the NPM setup task runs `npm ci` so the Vagrant development environment has the right dependencies on start.